### PR TITLE
Improve PHP 8.1 compat

### DIFF
--- a/lib/Horde/History/Log.php
+++ b/lib/Horde/History/Log.php
@@ -32,7 +32,7 @@ class Horde_History_Log implements IteratorAggregate, ArrayAccess, Countable
     /**
      * TODO
      */
-    protected $_data = array();
+    protected $_data = [];
 
     /**
      * Constructor.
@@ -67,32 +67,36 @@ class Horde_History_Log implements IteratorAggregate, ArrayAccess, Countable
         }
     }
 
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->_data);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->_data[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->_data[$offset];
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->_data[$offset] = $value;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->_data[$offset]);
     }
 
-    public function count()
+    public function count(): int
     {
         return count($this->_data);
     }


### PR DESCRIPTION
The usual mix of __serialize/__unserialize, added signatures where safely possibly and #[\ReturnTypeWillChange] where it would break PHP 7.4

@ChristophWurst is this something you want to adopt?