### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Horde/History/Log.php
+++ b/lib/Horde/History/Log.php
@@ -67,31 +67,37 @@ class Horde_History_Log implements IteratorAggregate, ArrayAccess, Countable
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->_data);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->_data[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->_data[$offset];
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->_data[$offset] = $value;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->_data[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->_data);

--- a/migration/Horde/History/2_horde_history_upgrade_autoincrement.php
+++ b/migration/Horde/History/2_horde_history_upgrade_autoincrement.php
@@ -6,7 +6,7 @@ class HordeHistoryUpgradeAutoIncrement extends Horde_Db_Migration_Base
         $this->changeColumn('horde_histories', 'history_id', 'autoincrementKey');
         try {
             $this->dropTable('horde_histories_seq');
-        } catch (Horde_Db_Exception $e) {
+        } catch (Exception $e) {
         }
     }
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/History/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/History/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde Histopry Unit Tests">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/History/Mock/MockTest.php
+++ b/test/Horde/History/Mock/MockTest.php
@@ -10,12 +10,12 @@
  */
 class Horde_History_Mock_MockTest extends Horde_History_TestBase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         self::$history = new Horde_History_Mock('test');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         self::$history = null;
     }

--- a/test/Horde/History/Mongo/MongoTest.php
+++ b/test/Horde/History/Mongo/MongoTest.php
@@ -24,7 +24,7 @@ class Horde_History_Mongo_MongoTest extends Horde_History_TestBase
     private $_dbname = 'horde_history_mongodbtest';
     private $_mongo;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (($config = self::getConfig('HISTORY_MONGO_TEST_CONFIG', __DIR__ . '/..')) &&
             isset($config['history']['mongo'])) {
@@ -44,7 +44,7 @@ class Horde_History_Mongo_MongoTest extends Horde_History_TestBase
         ));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         if (!empty($this->_mongo)) {
             $this->_mongo->selectDB(null)->drop();

--- a/test/Horde/History/Sql/Base.php
+++ b/test/Horde/History/Sql/Base.php
@@ -14,7 +14,7 @@ abstract class Horde_History_Sql_Base extends Horde_History_TestBase
     protected static $reason;
     protected static $logger;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -31,7 +31,7 @@ abstract class Horde_History_Sql_Base extends Horde_History_TestBase
         self::$history = new Horde_History_Sql('test_user', self::$db);
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         if (self::$db) {
             self::$db->disconnect();
@@ -39,7 +39,7 @@ abstract class Horde_History_Sql_Base extends Horde_History_TestBase
         self::$db = self::$migrator = null;
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         if (!self::$db) {
             $this->markTestSkipped(self::$reason);
@@ -53,7 +53,7 @@ abstract class Horde_History_Sql_Base extends Horde_History_TestBase
         self::$migrator->up();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         if (self::$migrator) {
             self::$migrator->down();
@@ -62,6 +62,7 @@ abstract class Horde_History_Sql_Base extends Horde_History_TestBase
 
     public function testMigration()
     {
+        self::expectNotToPerformAssertions();
         self::$migrator->migrate(1);
         self::$db->insert(
             'INSERT INTO horde_histories (history_id, object_uid, history_ts, history_who, history_desc, history_action, history_extra) VALUES (?, ?, ?, ?, ?, ?, ?)',

--- a/test/Horde/History/Sql/MysqlTest.php
+++ b/test/Horde/History/Sql/MysqlTest.php
@@ -11,7 +11,7 @@
  */
 class Horde_History_Sql_MysqlTest extends Horde_History_Sql_Base
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!extension_loaded('mysql')) {
             self::$reason = 'No mysql extension';

--- a/test/Horde/History/Sql/MysqliTest.php
+++ b/test/Horde/History/Sql/MysqliTest.php
@@ -11,7 +11,7 @@
  */
 class Horde_History_Sql_MysqliTest extends Horde_History_Sql_Base
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!extension_loaded('mysqli')) {
             self::$reason = 'No mysqli extension';

--- a/test/Horde/History/Sql/Oci8Test.php
+++ b/test/Horde/History/Sql/Oci8Test.php
@@ -10,7 +10,7 @@
  */
 class Horde_History_Sql_Oci8Test extends Horde_History_Sql_Base
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!extension_loaded('oci8')) {
             self::$reason = 'No oci8 extension';

--- a/test/Horde/History/Sql/Pdo/MysqlTest.php
+++ b/test/Horde/History/Sql/Pdo/MysqlTest.php
@@ -11,7 +11,7 @@
  */
 class Horde_History_Sql_Pdo_MysqlTest extends Horde_History_Sql_Base
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!extension_loaded('pdo') ||
             !in_array('mysql', PDO::getAvailableDrivers())) {

--- a/test/Horde/History/Sql/Pdo/PgsqlTest.php
+++ b/test/Horde/History/Sql/Pdo/PgsqlTest.php
@@ -11,7 +11,7 @@
  */
 class Horde_History_Sql_Pdo_PgsqlTest extends Horde_History_Sql_Base
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!extension_loaded('pdo') ||
             !in_array('pgsql', PDO::getAvailableDrivers())) {

--- a/test/Horde/History/TestBase.php
+++ b/test/Horde/History/TestBase.php
@@ -28,6 +28,7 @@ class Horde_History_TestBase extends Horde_Test_Case
 
     public function testMethodLogHasParameterStringGuid()
     {
+        $this->expectNotToPerformAssertions();
         try {
             self::$history->log(array());
             $this->fail('No exception!');
@@ -72,6 +73,7 @@ class Horde_History_TestBase extends Horde_Test_Case
 
     public function testMethodGethistoryHasParameterStringGuid()
     {
+        $this->expectNotToPerformAssertions();
         try {
             self::$history->getHistory(array());
             $this->fail('No exception!');
@@ -108,6 +110,7 @@ class Horde_History_TestBase extends Horde_Test_Case
 
     public function testMethodGetbytimestampHasParameterStringCmp()
     {
+        $this->expectNotToPerformAssertions();
         try {
             self::$history->getByTimestamp(array(), 1);
             $this->fail('No exception!');
@@ -117,6 +120,7 @@ class Horde_History_TestBase extends Horde_Test_Case
 
     public function testMethodGetbytimestampHasParameterIntegerTs()
     {
+        $this->expectNotToPerformAssertions();
         try {
             self::$history->getByTimestamp('>', 'hello');
             $this->fail('No exception!');
@@ -184,6 +188,7 @@ class Horde_History_TestBase extends Horde_Test_Case
 
     public function testMethodGetactiontimestampHasParameterStringGuid()
     {
+        $this->expectNotToPerformAssertions();
         try {
             self::$history->getActionTimestamp(array(), 'test');
             $this->fail('No exception!');
@@ -193,6 +198,7 @@ class Horde_History_TestBase extends Horde_Test_Case
 
     public function testMethodGetactiontimestampHasParameterStringAction()
     {
+        $this->expectNotToPerformAssertions();
         try {
             self::$history->getActionTimestamp('test', array());
             $this->fail('No exception!');
@@ -260,6 +266,7 @@ class Horde_History_TestBase extends Horde_Test_Case
 
     public function testMethodRemovebynamesSucceedsIfParameterNamesIsEmpty()
     {
+        $this->expectNotToPerformAssertions();
         self::$history->log('test_uid', array('who' => 'me', 'ts' => 1000, 'action' => 'test_action'));
         self::$history->log('test_uid', array('who' => 'me', 'ts' => 1000, 'action' => 'test_action'), false);
         self::$history->log('test_uid', array('who' => 'you', 'ts' => 2000, 'action' => 'yours_action'));


### PR DESCRIPTION
- Debian changes: Adapt to PHPUnit 8.x and 9.x API. https://salsa.debian.org/horde-team/php-horde-history/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian changes: Fix compilation and test failures on php 8.1 https://salsa.debian.org/horde-team/php-horde-history/-/blob/debian-sid/debian/patches/2010_phpunit-8.1.patch
